### PR TITLE
add support for auto-configuration of branding and certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,11 @@ WORKDIR /usr/src/app/dcc-portal-ui
 
 COPY dcc-portal-ui/ /usr/src/app/dcc-portal-ui
 
-RUN npm install
+# copy branding
+COPY dcc-portal-ui/config/CUSTOM_PATHS.js.example /usr/src/app/dcc-portal-ui/config/paths.js
+COPY dcc-portal-ui/config/CUSTOM_BRANDING.js.example /usr/src/app/dcc-portal-ui/config/branding.js
 
-EXPOSE 80 8000 9000
+RUN npm install
 
 
 RUN apt-get update

--- a/dcc-portal-ui/.gitignore
+++ b/dcc-portal-ui/.gitignore
@@ -9,3 +9,5 @@ data/users.htpasswd
 config/CUSTOM_BRANDING.js
 config/CUSTOM_PATHS.js
 translations/*.mo
+config/branding.js
+config/paths.js

--- a/dcc-portal-ui/config/webpack.config.prod.js
+++ b/dcc-portal-ui/config/webpack.config.prod.js
@@ -3,8 +3,7 @@ var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
-var paths = require('./ICGC_PATHS');
-// var paths = require('./CUSTOM_PATHS');
+var paths = require('./paths');
 
 module.exports = {
   bail: true,
@@ -63,8 +62,7 @@ module.exports = {
             },
             {
               search: '\<branding-settings\>\<\/branding-settings\>',
-              replace: `<script>window.$ICGC_BRANDING = ${JSON.stringify(require('./ICGC_BRANDING.js'))}</script>`
-//              replace: `<script>window.$ICGC_BRANDING = ${JSON.stringify(require('./CUSTOM_BRANDING.js'))}</script>`
+             replace: `<script>window.$ICGC_BRANDING = ${JSON.stringify(require('./branding.js'))}</script>`
             }
           ]
         }


### PR DESCRIPTION
This PR implements 1 new feature 
* add support for auto-configuration of branding and certificates [EUL-36,25]
* paired with euler PR https://github.com/ohsu-computational-biology/euler/pull/10

Implementation details:
* creation of [ config/branding.js, config/paths.js ] handled in dcc-portal-ui/Dockerfile
* tasks/start.js reads certs & keys from env variables, degrades to non secure if not provided
